### PR TITLE
🚀 fix: correctly resolve armv7 host

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -66,12 +66,8 @@ export function toFancyArch (arch) {
 }
 
 function getArmHostArch () {
-  const cpu = fs.readFileSync('/proc/cpuinfo', 'utf8');
-  if (cpu.indexOf('vfpv3') >= 0) return 'armv7';
-  let name = cpu.split('model name')[1];
-  if (name) name = name.split(':')[1];
-  if (name) name = name.split('\n')[0];
-  if (name && name.indexOf('ARMv7') >= 0) return 'armv7';
+  const arch = spawnSync('uname', ["-m"]).stdout.toString();
+  if (arch.startsWith("armv7")) return 'armv7';
   return 'armv6';
 }
 


### PR DESCRIPTION
Relying on `/proc/cpuinfo'` is not safe as it will not work when using emulation for building the binaries such as docker buildx.

`uname -m` is more reliably as it will return a string such as `armv7`.