### PR TITLE
Allow configuring number of processes used for compiling.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -59,6 +59,8 @@ async function compileOnWindows (nodeVersion, targetArch) {
   return path.join(nodePath, 'out/Release/node.exe');
 }
 
+const { MAKE_JOB_COUNT = '1' } = process.env;
+
 async function compileOnUnix (nodeVersion, targetArch) {
   const args = [];
   const cpu = { x86: 'ia32', x64: 'x64',
@@ -76,7 +78,7 @@ async function compileOnUnix (nodeVersion, targetArch) {
   // TODO same for windows?
   await spawn('./configure', args, { cwd: nodePath });
   const make = hostPlatform === 'freebsd' ? 'gmake' : 'make';
-  const promise = spawn(make, [], { cwd: nodePath });
+  const promise = spawn(make, [ '-j', MAKE_JOB_COUNT ], { cwd: nodePath });
   progress(promise, thresholds('make', nodeVersion));
   await promise;
   const output = path.join(nodePath, 'out/Release/node');


### PR DESCRIPTION
…via the MAKE_JOB_COUNT environment variable

This should in general speed up the building of node.