### PR TITLE
Improve ARM architecture detection: arm64 and armv7

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -65,6 +65,17 @@ export function toFancyArch (arch) {
   return arch;
 }
 
+function getArmUnameArch () {
+  const uname = spawnSync('uname', ['-a']);
+  if (uname.error) return '';
+  let unameOut = uname.stdout && uname.stdout.toString();
+  unameOut = (unameOut || '').toLowerCase();
+  if (unameOut.includes('aarch64')) return 'arm64';
+  if (unameOut.includes('arm64')) return 'arm64';
+  if (unameOut.includes('armv7')) return 'armv7';
+  return '';
+}
+
 function getArmHostArch () {
   const cpu = fs.readFileSync('/proc/cpuinfo', 'utf8');
   if (cpu.indexOf('vfpv3') >= 0) return 'armv7';
@@ -77,7 +88,7 @@ function getArmHostArch () {
 
 function getHostArch () {
   const { arch } = process;
-  if (arch === 'arm') return getArmHostArch();
+  if (arch === 'arm') return getArmUnameArch() || getArmHostArch();
   return toFancyArch(arch);
 }
 


### PR DESCRIPTION
When running `pkg` in a Docker Desktop ARM-image container on an Intel laptop, using `binfmt_misc` / QEMU architecture emulation, `/proc/cpuinfo` reports the Intel processor rather than the emulated ARM processor. The existing architecture detection then fails. Also, the existing detection code does not support arm64 (e.g. the Raspberry Pi 4), reporting `armv6` instead.