### PR TITLE
Allow cross compiling

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import uniqueTempDir from 'unique-temp-dir';
 
-import { hostPlatform } from './system';
+import { hostArch, hostPlatform } from './system';
 import { log } from './log';
 import patchesJson from '../patches/patches.json';
 
@@ -106,6 +106,12 @@ async function compileOnUnix(nodeVersion: string, targetArch: string) {
 
   if (cpu) {
     args.push('--dest-cpu', cpu);
+  }
+
+  if (hostArch !== targetArch) {
+    log.warn('Cross compiling!');
+    log.warn('You are responsible for appropriate env like CC, CC_host, etc.');
+    args.push('--cross-compiling');
   }
 
   // first of all v8_inspector introduces the use

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import semver from 'semver';
 import {
   abiToNodeRange,
-  hostArch,
   hostPlatform, // eslint-disable-line no-duplicate-imports
   isValidNodeRange,
   knownArchs,
@@ -145,12 +144,6 @@ export async function need(opts: NeedOptions) {
   if (hostPlatform !== platform) {
     throw wasReported(
       `Not able to build for '${opts.platform}' here, only for '${hostPlatform}'`
-    );
-  }
-
-  if (hostArch !== arch) {
-    throw wasReported(
-      `Not able to build for '${opts.arch}' here, only for '${hostArch}'`
     );
   }
 


### PR DESCRIPTION
To test on Ubuntu (amd64 host): 

```bash
# Install toolchain
$ sudo apt install build-essential gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu

# Set ENV for cross toolchain
$ export CC=/usr/bin/aarch64-linux-gnu-gcc CXX=/usr/bin/aarch64-linux-gnu-g++ AR=/usr/bin/aarch64-linux-gnu-ar NM=/usr/bin/aarch64-linux-gnu-nm READELF=/usr/bin/aarch64-linux-gnu-readelf

# Set ENV for host toolchain
$ export CC_host=/usr/bin/gcc CXX_host=/usr/bin/g++ AR_host=/usr/bin/ar NM_host=/usr/bin/nm READELF_host=/usr/bin/readelf

# Run pkg-fetch
$ pkg-fetch --force-build --arch arm64
```