### PR TITLE
Allow to override build path with PKG_BUILD_PATH

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -8,7 +8,7 @@ import { hostArch, hostPlatform } from './system';
 import { log } from './log';
 import patchesJson from '../patches/patches.json';
 
-const buildPath = uniqueTempDir();
+const buildPath = path.resolve(process.env.PKG_BUILD_PATH || uniqueTempDir());
 const nodePath = path.join(buildPath, 'node');
 const patchesPath = path.resolve(__dirname, '../patches');
 const nodeRepo = 'https://github.com/nodejs/node';


### PR DESCRIPTION
To allow us to workaround a path problem with older Node versions
and some Windows environments.