### PR TITLE
CI: add binary workflows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,84 @@
+name: Build Node binaries for Linux
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linux-x64:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [8, 10, 12, 14]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Red Hat Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_USERNAME }}
+          password: ${{ secrets.REDHAT_PASSWORD }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
+          context: .
+          file: ./Dockerfile.linux
+          platforms: linux/amd64
+          outputs: type=tar,dest=../out.tar
+
+      - name: Extract binaries from Docker image
+        run: |
+          tar xvf ../out.tar opt/app-root/src/.pkg-cache
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.target-node }}-linux-x64
+          path: opt/app-root/src/.pkg-cache/**/built-*
+
+  linux-arm64:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [8, 10, 12, 14]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: sudo apt update
+      - run: sudo apt install -y gcc-8-aarch64-linux-gnu g++-8-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+      - run: yarn install
+
+      - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64
+        env:
+          CC: /usr/bin/aarch64-linux-gnu-gcc-8
+          CXX: /usr/bin/aarch64-linux-gnu-g++-8
+          AR: /usr/bin/aarch64-linux-gnu-ar
+          NM: /usr/bin/aarch64-linux-gnu-nm
+          READELF: /usr/bin/aarch64-linux-gnu-readelf
+          CC_host: /usr/bin/gcc
+          CXX_host: /usr/bin/g++
+          AR_host: /usr/bin/ar
+          NM_host: /usr/bin/nm
+          READELF_host: /usr/bin/readelf
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.target-node }}-linux-arm64
+          path: /home/runner/.pkg-cache/**/built-*

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,34 @@
+name: Build Node binaries for macOS
+
+on:
+  workflow_dispatch:
+
+jobs:
+  macos-x64:
+    runs-on: macos-11.0
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [8, 10, 12, 14]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: yarn install
+
+      - run: yarn start --node-range node${{ matrix.target-node }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.target-node }}-macos-x64
+          path: /Users/runner/.pkg-cache/**/built-*

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,67 @@
+name: Build Node binaries for Windows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  windows-vs2017:
+    runs-on: windows-2016
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [8, 10, 12]
+        target-arch: [x64]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '2.x'
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: yarn install
+
+      - run: choco install nasm
+
+      - run: yarn start --node-range node${{ matrix.target-node }} --arch ${{ matrix.target-arch }}
+        env:
+          PKG_BUILD_PATH: build
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.target-node }}-windows-${{ matrix.target-arch }}
+          path: C:\\Users\\runneradmin\\.pkg-cache\\**\\built-*
+
+  windows-vs2019:
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [14]
+        target-arch: [x64, arm64]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: yarn install
+
+      - run: choco install nasm
+
+      - run: yarn start --node-range node${{ matrix.target-node }} --arch ${{ matrix.target-arch }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.target-node }}-windows-${{ matrix.target-arch }}
+          path: C:\\Users\\runneradmin\\.pkg-cache\\**\\built-*

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,0 +1,22 @@
+FROM registry.redhat.io/rhscl/devtoolset-10-toolchain-rhel7
+
+ARG PKG_FETCH_OPTION_n
+
+USER root:root
+
+WORKDIR /root/pkg-fetch/
+
+COPY . ./
+
+RUN yum install -y glibc-headers kernel-headers git make python2 python3 rh-nodejs14-npm && scl enable rh-nodejs14 bash
+
+ENV LD_LIBRARY_PATH /opt/rh/rh-nodejs14/root/usr/lib64:$LD_LIBRARY_PATH
+ENV MANPATH /opt/rh/rh-nodejs14/root/usr/share/man:$MANPATH
+ENV PATH /opt/rh/rh-nodejs14/root/usr/bin:$PATH
+ENV PYTHONPATH /opt/rh/rh-nodejs14/root/usr/lib/python2.7/site-packages
+
+RUN npm install -g yarn
+
+RUN yarn install
+
+RUN yarn start --node-range $PKG_FETCH_OPTION_n


### PR DESCRIPTION
Linux: https://github.com/jesec/pkg-fetch/actions/runs/711723135

Windows: https://github.com/jesec/pkg-fetch/actions/runs/711723405

* Node < 14 does not support cross compilation for win-arm64

macOS: https://github.com/jesec/pkg-fetch/actions/runs/711723492

* There is no support for cross compilation on macOS. Plus, the signing issue with Apple Silicon: https://github.com/jesec/pkg-fetch/releases/tag/v2.7 . 

This should allow us to release 3.0.

@leerob , after we merge this change, please:

1. Bump and tag version. Build and release to npm.
1. Go to `Actions` and run binary workflows.
1. Fetch the binaries from `Actions` after workflows finish.
1. Rename from `built-*` to `node-*`. 
1. Upload them to a `v3.0` release. (strictly vMAJOR.MINOR here. no patch. patch releases are not expected to change binaries)

Users of `pkg` are not going to be affected by the new `pkg-fetch` release at this moment, as `pkg` uses a pre-defined version of `pkg-fetch`. 

With a new release of `pkg-fetch` and binaries ready, we can go back to `pkg`, bump the `pkg-fetch`, and run the test suite. If everything goes well, we can do a release there, but we can also wait a while. 

I plan to add support for a fully static (Linux) variant soon. Additionally, I think we can tweak the `configure` arguments of Node to make the binaries smaller. And, should we `strip` (debugging symbols from) binaries? 