### PR TITLE
Include TypeScript types in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "lib-es5/*.js",
+    "lib-es5/*.ts",
     "patches/*"
   ],
   "dependencies": {


### PR DESCRIPTION
So we can use proper types in `pkg`. 