### PR TITLE
log: expand progress bar width to 35

### DIFF
--- a/lib/log.ts
+++ b/lib/log.ts
@@ -52,7 +52,7 @@ class Log {
   enableProgress(text: string) {
     assert(!this.bar);
 
-    text += ' '.repeat(28 - text.length);
+    text += ' '.repeat(35 - text.length);
     this.bar = new Progress(`  ${text} [:bar] :percent`, {
       stream: process.stdout,
       width: 20,


### PR DESCRIPTION
Otherwise we can't use "linuxstatic" due to progress bar out of range...