### PR TITLE
Build x86 for Windows at least for the LTS release

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         target-node: [14, 16]
-        target-arch: [x64, arm64]
+        target-arch: [x64, arm64, x86]
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -55,7 +55,13 @@ function getConfigureArgs(major: number, targetPlatform: string): string[] {
   args.push('--without-npm');
 
   // Small ICU
-  args.push('--with-intl=small-icu');
+  
+  
+  if (hostPlatform === 'win') {  
+    args.push('--with-intl=full-icu');
+  } else {
+    args.push('--with-intl=small-icu');
+  }
 
   return args;
 }


### PR DESCRIPTION
With this PR I would like to add `x86` for Windows. Seeing the popularity here:

![Arch stats](https://nodejs.org/metrics/summaries/arch.png)

At least way more popular then the other architectures included in the build. Porting to x64 for Windows is not as straight forward, specially when you have an C++ ABI to NodeJS