### PR TITLE
Use relative offsets for prelude and payload to enable upx packing

### DIFF
--- a/patches/node.v10.24.1.cpp.patch
+++ b/patches/node.v10.24.1.cpp.patch
@@ -209,8 +209,8 @@
  
 --- node/lib/internal/bootstrap/node.js
 +++ node/lib/internal/bootstrap/node.js
-@@ -213,10 +213,47 @@
- 
+@@ -213,10 +213,48 @@
+
      // There are various modes that Node can run in. The most common two
      // are running from a script and running the REPL - but there are a few
      // others like the debugger or running --eval arguments. Here we decide
@@ -224,13 +224,14 @@
 +        var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
 +        var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
 +        var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
-+        if (!PRELUDE_POSITION) {
++        if (!PRELUDE_SIZE) {
 +          // no prelude - remove entrypoint from argv[1]
 +          process.argv.splice(1, 1);
 +          return { undoPatch: true };
 +        }
++        var filesize = fs.fstatSync(fd).size;
 +        var prelude = Buffer.alloc(PRELUDE_SIZE);
-+        var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++        var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, filesize - PRELUDE_SIZE);
 +        if (read !== PRELUDE_SIZE) {
 +          console.error('Pkg: Error reading from file.');
 +          process.exit(1);
@@ -238,7 +239,7 @@
 +        var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
 +        var fn = s.runInThisContext();
 +        return fn(process, NativeModule.require,
-+          console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++          console, fd, filesize - PRELUDE_SIZE - PAYLOAD_SIZE, PAYLOAD_SIZE);
 +      }
 +      (function () {
 +        var fd = fs.openSync(process.execPath, 'r');

--- a/patches/node.v12.22.1.cpp.patch
+++ b/patches/node.v12.22.1.cpp.patch
@@ -183,7 +183,7 @@ new file mode 100644
 index 0000000000..fb2d47f52b
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,45 @@
 +'use strict';
 +
 +const {
@@ -201,13 +201,14 @@ index 0000000000..fb2d47f52b
 +    var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
 +    var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
 +    var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
-+    if (!PRELUDE_POSITION) {
++    if (!PRELUDE_SIZE) {
 +      // no prelude - remove entrypoint from argv[1]
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var filesize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
-+    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, filesize - PRELUDE_SIZE);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');
 +      process.exit(1);
@@ -215,7 +216,7 @@ index 0000000000..fb2d47f52b
 +    var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
 +    var fn = s.runInThisContext();
 +    return fn(process, __require__,
-+      console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++      console, fd, filesize - PRELUDE_SIZE - PAYLOAD_SIZE, PAYLOAD_SIZE);
 +  }
 +  (function () {
 +    var fd = fs.openSync(process.execPath, 'r');

--- a/patches/node.v14.16.1.cpp.patch
+++ b/patches/node.v14.16.1.cpp.patch
@@ -182,7 +182,7 @@
 new file mode 100644
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,45 @@
 +'use strict';
 +
 +const {
@@ -200,13 +200,14 @@ new file mode 100644
 +    var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
 +    var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
 +    var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
-+    if (!PRELUDE_POSITION) {
++    if (!PRELUDE_SIZE) {
 +      // no prelude - remove entrypoint from argv[1]
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var filesize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
-+    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, filesize - PRELUDE_SIZE);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');
 +      process.exit(1);
@@ -214,7 +215,7 @@ new file mode 100644
 +    var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
 +    var fn = s.runInThisContext();
 +    return fn(process, __require__,
-+      console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++      console, fd, filesize - PRELUDE_SIZE - PAYLOAD_SIZE, PAYLOAD_SIZE);
 +  }
 +  (function () {
 +    var fd = fs.openSync(process.execPath, 'r');

--- a/patches/node.v16.0.0.cpp.patch
+++ b/patches/node.v16.0.0.cpp.patch
@@ -141,7 +141,7 @@
 index 0000000000..fb2d47f52b
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,45 @@
 +'use strict';
 +
 +const {
@@ -159,13 +159,14 @@ index 0000000000..fb2d47f52b
 +    var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
 +    var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
 +    var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
-+    if (!PRELUDE_POSITION) {
++    if (!PRELUDE_SIZE) {
 +      // no prelude - remove entrypoint from argv[1]
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var filesize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
-+    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, filesize - PRELUDE_SIZE);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');
 +      process.exit(1);
@@ -173,7 +174,7 @@ index 0000000000..fb2d47f52b
 +    var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
 +    var fn = s.runInThisContext();
 +    return fn(process, __require__,
-+      console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++      console, fd, filesize - PRELUDE_SIZE - PAYLOAD_SIZE, PAYLOAD_SIZE);
 +  }
 +  (function () {
 +    var fd = fs.openSync(process.execPath, 'r');

--- a/patches/node.v8.17.0.cpp.patch
+++ b/patches/node.v8.17.0.cpp.patch
@@ -198,7 +198,7 @@
    // set process.send()
 --- node/lib/internal/bootstrap_node.js
 +++ node/lib/internal/bootstrap_node.js
-@@ -122,10 +122,46 @@
+@@ -122,10 +122,47 @@
      // There are various modes that Node can run in. The most common two
      // are running from a script and running the REPL - but there are a few
      // others like the debugger or running --eval arguments. Here we decide
@@ -212,13 +212,14 @@
 +        var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
 +        var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
 +        var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
-+        if (!PRELUDE_POSITION) {
++        if (!PRELUDE_SIZE) {
 +          // no prelude - remove entrypoint from argv[1]
 +          process.argv.splice(1, 1);
 +          return { undoPatch: true };
 +        }
++        var filesize = fs.fstatSync(fd).size;
 +        var prelude = new Buffer(PRELUDE_SIZE);
-+        var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++        var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, filesize - PRELUDE_SIZE);
 +        if (read !== PRELUDE_SIZE) {
 +          console.error('Pkg: Error reading from file.');
 +          process.exit(1);
@@ -226,7 +227,7 @@
 +        var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
 +        var fn = s.runInThisContext();
 +        return fn(process, NativeModule.require,
-+          console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++          console, fd, filesize - PRELUDE_SIZE - PAYLOAD_SIZE, PAYLOAD_SIZE);
 +      }
 +      (function () {
 +        var fd = fs.openSync(process.execPath, 'r');


### PR DESCRIPTION
As mentioned in this comment: https://github.com/vercel/pkg/issues/50#issuecomment-789951164, the only thing preventing the use of [https://github.com/upx/upx](https://github.com/upx/upx) to bring down the linux binary size significantly is that the offsets of the prelude and payload are currently hardcoded.

This PR changes that, because it's completely unneccessary as far as I can tell.
I haven't removed the fields that contain the offsets to maintain backward-compatibility.
This could be changed of course

Using this in conjunction with https://github.com/vercel/pkg/pull/1115/, I was able to trim down the size of my application from 33.58MB to 8.7MB

To achieve this, I first run pkg with custom base binaries including these patches, then split the output binary into the runtime with baked-in data and application data, `upx --ultra-brute` compress the binary and finally concat the two back together.