### PR TITLE
build: strip signature from compiled macOS base binary

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -205,6 +205,14 @@ async function compileOnUnix(
     stdio: 'inherit',
   });
 
+  if (targetPlatform === 'macos') {
+    // Newer versions of Apple Clang automatically ad-hoc sign the compiled executable.
+    // However, for final executable to be signable, base binary MUST NOT have an existing signature.
+    await spawn('codesign', ['--remove-signature', output], {
+      stdio: 'inherit',
+    });
+  }
+
   return output;
 }
 


### PR DESCRIPTION
Newer versions of Apple Clang automatically ad-hoc sign the compiled
executable, due to the new mandatory code signing requirement [1].

However, for final executable to be signable, base binary MUST NOT
have an existing signature.

This change strips the ad-hoc signature from compiled macOS base binary.

[1]: https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes

Refs: vercel/pkg#1164
Bug: vercel/pkg#1023