### PR TITLE
build: don't strip global symbols of macOS binaries

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -201,9 +201,14 @@ async function compileOnUnix(
 
   const output = path.join(nodePath, 'out/Release/node');
 
-  await spawn(process.env.STRIP || 'strip', [output], {
-    stdio: 'inherit',
-  });
+  await spawn(
+    process.env.STRIP || 'strip',
+    // global symbols are required for native bindings on macOS
+    [...(targetPlatform === 'macos' ? ['-x'] : []), output],
+    {
+      stdio: 'inherit',
+    }
+  );
 
   return output;
 }


### PR DESCRIPTION
Global symbols are required for native bindings on macOS.

Bug: vercel/pkg#1155