### PR TITLE
Working on v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pkg-fetch",
-  "version": "3.0.4",
+  "version": "3.1.0-pre",
   "description": "Compiles and stores base binaries for pkg",
   "main": "lib-es5/index.js",
   "license": "MIT",


### PR DESCRIPTION
CI workflows skip existing binaries in the same minor version. However,
some changes require us to rebuild and replace binaries.

As such, bump the minor version and create a Git tag to store the binaries.

Binaries to be carried over from v3.0:

- alpine, linux, linuxstatic and win

macOS ones would be recompiled due to 5d2bc3bb2, and Node 16.0.0
binaries will be dropped in v3.1.

No npm release is required for this change. We will do that after
binaries are compiled and hashes are updated.