### PR TITLE
patches: workaround the js2c command issue with node16-win

### DIFF
--- a/patches/node.v16.1.0.cpp.patch
+++ b/patches/node.v16.1.0.cpp.patch
@@ -263,6 +263,15 @@ index 0000000000..fb2d47f52b
        'lib/internal/bootstrap/pre_execution.js',
        'lib/internal/bootstrap/switches/does_own_process_state.js',
        'lib/internal/bootstrap/switches/does_not_own_process_state.js',
+@@ -1049,7 +1049,7 @@
+             'config.gypi'
+           ],
+           'outputs': [
+-            '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
++            '<(SHARED_INTERMEDIATE_DIR)/node_js.cc',
+           ],
+           'action': [
+             'python', '<@(_inputs)',
 --- node/src/inspector_agent.cc
 +++ node/src/inspector_agent.cc
 @@ -682,8 +682,6 @@ bool Agent::Start(const std::string& path,


### PR DESCRIPTION
Apparently with nodejs/node@54dfdbccc and our addition of a bootstrap
script entry, we hit some sorts of limits on Windows platform.

Mysteriously a command starts to fail. I suspect that we happen to
reach the maximum command line argument length on Windows.

This change is a quick hack to bring the command below the limit. It
does not change the functionality in any way. Upstream is going to
notice this issue soon, when they add another internal JavaScript
function.