### PR TITLE
CI: use Docker to build binaries for linux-arm64

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -51,7 +51,7 @@ jobs:
           path: root/pkg-fetch/dist/*
 
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -61,37 +61,32 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 14
-        uses: actions/setup-node@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build
+        uses: docker/build-push-action@v2
         with:
-          node-version: 14
+          build-args: |
+            TARGET_TOOLCHAIN_ARCH=aarch64
+            PKG_FETCH_OPTION_a=arm64
+            PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
+          context: .
+          file: ./Dockerfile.linuxcross
+          platforms: linux/amd64
+          outputs: type=tar,dest=../out.tar
 
-      - run: sudo apt update
-      - run: sudo apt install -y gcc-8-aarch64-linux-gnu g++-8-aarch64-linux-gnu binutils-aarch64-linux-gnu
-
-      - run: yarn install
-
-      - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
-        env:
-          CC: /usr/bin/aarch64-linux-gnu-gcc-8
-          CXX: /usr/bin/aarch64-linux-gnu-g++-8
-          AR: /usr/bin/aarch64-linux-gnu-ar
-          NM: /usr/bin/aarch64-linux-gnu-nm
-          READELF: /usr/bin/aarch64-linux-gnu-readelf
-          STRIP: /usr/bin/aarch64-linux-gnu-strip
-          CC_host: /usr/bin/gcc
-          CXX_host: /usr/bin/g++
-          AR_host: /usr/bin/ar
-          NM_host: /usr/bin/nm
-          READELF_host: /usr/bin/readelf
+      - name: Extract binaries from Docker image
+        run: |
+          tar xvf ../out.tar root/pkg-fetch/dist
 
       - name: Check if binary is compiled
         id: check_file
         run: |
-          (test -f dist/*.sha256sum && echo ::set-output name=EXISTS::true) || echo ::set-output name=EXISTS::false
+          (test -f root/pkg-fetch/dist/*.sha256sum && echo ::set-output name=EXISTS::true) || echo ::set-output name=EXISTS::false
 
       - uses: actions/upload-artifact@v2
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-linux-arm64
-          path: dist/*
+          path: root/pkg-fetch/dist/*

--- a/Dockerfile.linuxcross
+++ b/Dockerfile.linuxcross
@@ -1,0 +1,38 @@
+FROM ubuntu:bionic
+
+ARG TARGET_TOOLCHAIN_ARCH
+
+ARG PKG_FETCH_OPTION_a
+ARG PKG_FETCH_OPTION_n
+
+USER root:root
+WORKDIR /root/pkg-fetch/
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y curl software-properties-common
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs
+
+RUN apt-get install -y binutils gcc-8 g++-8 git make patch python python3 python3-distutils
+RUN apt-get install -y binutils-$TARGET_TOOLCHAIN_ARCH-linux-gnu gcc-8-$TARGET_TOOLCHAIN_ARCH-linux-gnu g++-8-$TARGET_TOOLCHAIN_ARCH-linux-gnu
+
+ENV CC=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-gcc-8
+ENV CXX=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-g++-8
+ENV AR=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-ar
+ENV NM=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-nm
+ENV READELF=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-readelf
+ENV STRIP=/usr/bin/$TARGET_TOOLCHAIN_ARCH-linux-gnu-strip
+ENV CC_host=/usr/bin/gcc-8
+ENV CXX_host=/usr/bin/g++-8
+ENV AR_host=/usr/bin/ar
+ENV NM_host=/usr/bin/nm
+ENV READELF_host=/usr/bin/readelf
+
+RUN npm install -g yarn
+
+COPY . ./
+
+RUN yarn install
+
+RUN yarn start --arch $PKG_FETCH_OPTION_a --node-range $PKG_FETCH_OPTION_n --output dist


### PR DESCRIPTION
Recently it comes to my attention that Github Actions image installs
experimental C++ standard library from an unsupported PPA, which
effectively breaks assumptions of binary compatibility for the OS
(in this case, Ubuntu 18.04+).

Unfortunately, as a result, the Github Actions environment can no
longer be trusted to compile proper binaries.

This change adds a Dockerfile that composes a proper Ubuntu 18.04
environment from official "ubuntu:bionic" image, and builds Node
binaries in it.

Refs: actions/virtual-environments#3376, actions/virtual-environments#3432, actions/virtual-environments#3459