### PR TITLE
More logging which file is used for built

### DIFF
--- a/lib/places.ts
+++ b/lib/places.ts
@@ -1,6 +1,7 @@
 import { major, minor } from 'semver';
 import os from 'os';
 import path from 'path';
+import { log } from './log';
 
 const { PKG_CACHE_PATH } = process.env;
 const IGNORE_TAG = Boolean(process.env.PKG_IGNORE_TAG);
@@ -43,11 +44,13 @@ export function localPlace({
       ? path.join(cachePath)
       : path.join(cachePath, tagFromVersion(version));
   }
-
-  return path.resolve(
+  
+  let file =  path.resolve(
     binDir,
     `${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}`
   );
+  log.info('looking for node built in: ',file);
+  return file;
 }
 
 export interface Remote {


### PR DESCRIPTION
So I was setting `PKG_CACHE_PATH` however my build was not found. By looking in the code I found that the `bindir` was changed

Also it is nice to see that `PKG_CACHE_PATH`  is used, since I was first not sure if it was used (environments var not so straightforward on win platform)

Wat this extra logging you at least can see where it looks for. I'm happy to receive comments on improvement.