### PR TITLE
Add support for source tarball builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ A utility to fetch or build patched Node binaries used by [pkg](https://github.c
 
 <em id="fn3">[3]</em>: [mandatory code signing](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes) is enforced by Apple.
 
+## Building Binaries
+
+In `--force-build` mode the source is cloned using `git` from [Node.js canonical repository][1]. Eventually, in e.g. network restricted environments it can be provided directly by setting environment variable `PKG_SOURCE_TAR` value to a path to [Node.js source tarball][2]. In such case tarball version must match desired Node.js range otherwise patching will fail. See all available [patches](patches/).
+
+Build directory can be changed by `PKG_BUILD_PATH` environment variable. Built (and fetched) binaries will be persisted in between the builds in `.pkg-cache/` in user's home directory if not overriden by value of `PKG_CACHE_PATH` environment variable.
+
+[1]: https://github.com/nodejs/node
+[2]: https://nodejs.org/en/download/releases/
+
 ## Security
 
 We do not expect this project to have vulnerabilities of its own. Nonetheless, as this project distributes prebuilt Node.js binaries,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -92,8 +92,11 @@ export async function spawn(
   args?: ReadonlyArray<string>,
   options?: SpawnSyncOptions
 ): Promise<void> {
-  const { error } = spawnSync(command, args, options);
+  const { status, error } = spawnSync(command, args, options);
   if (error) {
     throw error;
+  }
+  if (status !== 0) {
+    throw new Error(`non-zero exit code (${status}) from ${command}`)
   }
 }


### PR DESCRIPTION
In `--force-build` mode pkg-fetch clones desired Node.js source from
Github which is impractical for network-restricted (e.g. corporate)
environments and also fully reproducible builds. This changeset adds
support for building from official Node.js source tarballs via setting
`PKG_SOURCE_TAR` pointing to archive.

This also fixes relevant bug in `spawn()` which did not throw when exit
code of command is non-zero. Such behavior causes various problems (e.g.
when tar returns non-zero program would continue and attempt to patch).

Signed-off-by: Ondrej Balaz <blami@blami.net>