### PR TITLE
patches: do not optimize "BAKERY" placeholder out (GCC ver.), bump to 16.13.0

### DIFF
--- a/patches/node.v12.22.7.cpp.patch
+++ b/patches/node.v12.22.7.cpp.patch
@@ -567,7 +567,7 @@ index 0000000000..fb2d47f52b
  }
  #else
  // UNIX
-@@ -123,6 +125,76 @@ int main(int argc, char* argv[]) {
+@@ -123,6 +125,88 @@ int main(int argc, char* argv[]) {
    // calls elsewhere in the program (e.g., any logging from V8.)
    setvbuf(stdout, nullptr, _IONBF, 0);
    setvbuf(stderr, nullptr, _IONBF, 0);
@@ -623,12 +623,12 @@ index 0000000000..fb2d47f52b
 +
 +#ifdef __clang__
 +__attribute__((optnone))
++#elif defined(__GNUC__)
++__attribute__((optimize(0)))
  #endif
-+int reorder(int argc, char** argv) {
-+  int i;
-+  char** nargv = new char*[argc + 64];
-+  int c = 0;
-+  nargv[c++] = argv[0];
++int load_baked(char** nargv) {
++  int c = 1;
++
 +  char* bakery = (char*) BAKERY;
 +  while (true) {
 +    size_t width = strlen2(bakery);
@@ -636,12 +636,24 @@ index 0000000000..fb2d47f52b
 +    nargv[c++] = bakery;
 +    bakery += width + 1;
 +  }
++
++  return c;
++}
++
++int reorder(int argc, char** argv) {
++  char** nargv = new char*[argc + 64];
++
++  nargv[0] = argv[0];
++  int c = load_baked(nargv);
++
 +  if (should_set_dummy()) {
 +    nargv[c++] = (char*) "PKG_DUMMY_ENTRYPOINT";
 +  }
-+  for (i = 1; i < argc; i++) {
++
++  for (int i = 1; i < argc; i++) {
 +    nargv[c++] = argv[i];
 +  }
++
 +  return adjacent(c, nargv);
 +}
 --- node/src/node_options.cc

--- a/patches/node.v14.18.1.cpp.patch
+++ b/patches/node.v14.18.1.cpp.patch
@@ -448,7 +448,7 @@ index 0000000000..fb2d47f52b
  }
  #else
  // UNIX
-@@ -138,6 +140,76 @@ int main(int argc, char* argv[]) {
+@@ -138,6 +140,88 @@ int main(int argc, char* argv[]) {
    // calls elsewhere in the program (e.g., any logging from V8.)
    setvbuf(stdout, nullptr, _IONBF, 0);
    setvbuf(stderr, nullptr, _IONBF, 0);
@@ -504,12 +504,12 @@ index 0000000000..fb2d47f52b
 +
 +#ifdef __clang__
 +__attribute__((optnone))
++#elif defined(__GNUC__)
++__attribute__((optimize(0)))
  #endif
-+int reorder(int argc, char** argv) {
-+  int i;
-+  char** nargv = new char*[argc + 64];
-+  int c = 0;
-+  nargv[c++] = argv[0];
++int load_baked(char** nargv) {
++  int c = 1;
++
 +  char* bakery = (char*) BAKERY;
 +  while (true) {
 +    size_t width = strlen2(bakery);
@@ -517,12 +517,24 @@ index 0000000000..fb2d47f52b
 +    nargv[c++] = bakery;
 +    bakery += width + 1;
 +  }
++
++  return c;
++}
++
++int reorder(int argc, char** argv) {
++  char** nargv = new char*[argc + 64];
++
++  nargv[0] = argv[0];
++  int c = load_baked(nargv);
++
 +  if (should_set_dummy()) {
 +    nargv[c++] = (char*) "PKG_DUMMY_ENTRYPOINT";
 +  }
-+  for (i = 1; i < argc; i++) {
++
++  for (int i = 1; i < argc; i++) {
 +    nargv[c++] = argv[i];
 +  }
++
 +  return adjacent(c, nargv);
 +}
 --- node/src/node_options.cc

--- a/patches/node.v16.13.0.cpp.patch
+++ b/patches/node.v16.13.0.cpp.patch
@@ -411,7 +411,7 @@ index 0000000000..fb2d47f52b
  }
  #else
  // UNIX
-@@ -124,6 +126,76 @@ int main(int argc, char* argv[]) {
+@@ -124,6 +126,88 @@ int main(int argc, char* argv[]) {
    // calls elsewhere in the program (e.g., any logging from V8.)
    setvbuf(stdout, nullptr, _IONBF, 0);
    setvbuf(stderr, nullptr, _IONBF, 0);
@@ -467,12 +467,12 @@ index 0000000000..fb2d47f52b
 +
 +#ifdef __clang__
 +__attribute__((optnone))
++#elif defined(__GNUC__)
++__attribute__((optimize(0)))
  #endif
-+int reorder(int argc, char** argv) {
-+  int i;
-+  char** nargv = new char*[argc + 64];
-+  int c = 0;
-+  nargv[c++] = argv[0];
++int load_baked(char** nargv) {
++  int c = 1;
++
 +  char* bakery = (char*) BAKERY;
 +  while (true) {
 +    size_t width = strlen2(bakery);
@@ -480,12 +480,24 @@ index 0000000000..fb2d47f52b
 +    nargv[c++] = bakery;
 +    bakery += width + 1;
 +  }
++
++  return c;
++}
++
++int reorder(int argc, char** argv) {
++  char** nargv = new char*[argc + 64];
++
++  nargv[0] = argv[0];
++  int c = load_baked(nargv);
++
 +  if (should_set_dummy()) {
 +    nargv[c++] = (char*) "PKG_DUMMY_ENTRYPOINT";
 +  }
-+  for (i = 1; i < argc; i++) {
++
++  for (int i = 1; i < argc; i++) {
 +    nargv[c++] = argv[i];
 +  }
++
 +  return adjacent(c, nargv);
 +}
 --- node/src/node_options.cc

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,5 +1,5 @@
 {
-  "v16.12.0": ["node.v16.12.0.cpp.patch"],
+  "v16.13.0": ["node.v16.13.0.cpp.patch"],
   "v14.18.1": ["node.v14.18.1.cpp.patch"],
   "v12.22.7": ["node.v12.22.7.cpp.patch"],
   "v10.24.1": ["node.v10.24.1.cpp.patch"],


### PR DESCRIPTION
Bug: #223, vercel/pkg#1358