### PR TITLE
Dynamically discover the prelude

### DIFF
--- a/patches/node.v12.22.11.cpp.patch
+++ b/patches/node.v12.22.11.cpp.patch
@@ -280,7 +280,7 @@
 index 0000000000..fb2d47f52b
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,59 @@
 +'use strict';
 +
 +const {
@@ -303,7 +303,22 @@ index 0000000000..fb2d47f52b
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var fileSize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
++    var windowSize = 32768;
++    var windowShift = 24576;
++    var window = Buffer.alloc(windowSize);
++    var windowOffset = fileSize;
++    var preludeIdx = -1;
++    while (preludeIdx === -1 && windowOffset > 0) {
++       windowOffset = Math.max(windowOffset - windowShift, 0);
++       fs.readSync(fd, window, {position: windowOffset, length: windowSize});
++       preludeIdx = window.indexOf("(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {");
++    }
++    if (preludeIdx !== -1) {
++       PRELUDE_POSITION = windowOffset + preludeIdx;
++       PAYLOAD_POSITION = PRELUDE_POSITION - PAYLOAD_SIZE;
++    }
 +    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');

--- a/patches/node.v14.19.1.cpp.patch
+++ b/patches/node.v14.19.1.cpp.patch
@@ -169,7 +169,7 @@
 index 0000000000..fb2d47f52b
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,59 @@
 +'use strict';
 +
 +const {
@@ -192,7 +192,22 @@ index 0000000000..fb2d47f52b
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var fileSize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
++    var windowSize = 32768;
++    var windowShift = 24576;
++    var window = Buffer.alloc(windowSize);
++    var windowOffset = fileSize;
++    var preludeIdx = -1;
++    while (preludeIdx === -1 && windowOffset > 0) {
++       windowOffset = Math.max(windowOffset - windowShift, 0);
++       fs.readSync(fd, window, {position: windowOffset, length: windowSize});
++       preludeIdx = window.indexOf("(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {");
++    }
++    if (preludeIdx !== -1) {
++       PRELUDE_POSITION = windowOffset + preludeIdx;
++       PAYLOAD_POSITION = PRELUDE_POSITION - PAYLOAD_SIZE;
++    }
 +    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');

--- a/patches/node.v16.14.2.cpp.patch
+++ b/patches/node.v16.14.2.cpp.patch
@@ -142,7 +142,7 @@
 index 0000000000..fb2d47f52b
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,59 @@
 +'use strict';
 +
 +const {
@@ -165,7 +165,22 @@ index 0000000000..fb2d47f52b
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var fileSize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
++    var windowSize = 32768;
++    var windowShift = 24576;
++    var window = Buffer.alloc(windowSize);
++    var windowOffset = fileSize;
++    var preludeIdx = -1;
++    while (preludeIdx === -1 && windowOffset > 0) {
++       windowOffset = Math.max(windowOffset - windowShift, 0);
++       fs.readSync(fd, window, {position: windowOffset, length: windowSize});
++       preludeIdx = window.indexOf("(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {");
++    }
++    if (preludeIdx !== -1) {
++       PRELUDE_POSITION = windowOffset + preludeIdx;
++       PAYLOAD_POSITION = PRELUDE_POSITION - PAYLOAD_SIZE;
++    }
 +    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');

--- a/patches/node.v17.8.0.cpp.patch
+++ b/patches/node.v17.8.0.cpp.patch
@@ -153,7 +153,7 @@
 index 00000000000..fb2d47f52b6
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,59 @@
 +'use strict';
 +
 +const {
@@ -176,7 +176,22 @@ index 00000000000..fb2d47f52b6
 +      process.argv.splice(1, 1);
 +      return { undoPatch: true };
 +    }
++    var fileSize = fs.fstatSync(fd).size;
 +    var prelude = Buffer.alloc(PRELUDE_SIZE);
++    var windowSize = 32768;
++    var windowShift = 24576;
++    var window = Buffer.alloc(windowSize);
++    var windowOffset = fileSize;
++    var preludeIdx = -1;
++    while (preludeIdx === -1 && windowOffset > 0) {
++       windowOffset = Math.max(windowOffset - windowShift, 0);
++       fs.readSync(fd, window, {position: windowOffset, length: windowSize});
++       preludeIdx = window.indexOf("(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {");
++    }
++    if (preludeIdx !== -1) {
++       PRELUDE_POSITION = windowOffset + preludeIdx;
++       PAYLOAD_POSITION = PRELUDE_POSITION - PAYLOAD_SIZE;
++    }
 +    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
 +    if (read !== PRELUDE_SIZE) {
 +      console.error('Pkg: Error reading from file.');


### PR DESCRIPTION
After procrastinating for a whole year (#175), I've decided to take another look at this topic and came up with a solution, which should enable users to both use UPX compression and sign their binaries.

This is done by dynamically searching for the beginning of the prelude on startup.
As memory usage can be a concern, this is done by looking at chunks of 32KiB starting at the end of the file, shifting the window on each iteration by only 24KiB to deal with the possibility of the prelude beginning right in the middle of two 32KiB chunks. These values have been chosen by fair dice roll.


As it is now, it searches for the string `"(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {"`, which isn't ideal. One idea would be to just name that function in `pkg`. Maybe something along the lines of `function preludeExecutor(`?

Please let me know what you think of this approach