### PR TITLE
fetch package via mirror environment variable: PKG_FETCH_MIRROR

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,11 +19,15 @@ import { downloadUrl, hash, plusx } from './utils';
 import patchesJson from '../patches/patches.json';
 import { version } from '../package.json';
 
+const { PKG_FETCH_MIRROR } = process.env;
+
 async function download(
   { tag, name }: Remote,
   local: string
 ): Promise<boolean> {
-  const url = `https://github.com/vercel/pkg-fetch/releases/download/${tag}/${name}`;
+  const url = typeof PKG_FETCH_MIRROR !== "undefined" ?
+      `${PKG_FETCH_MIRROR}/${tag}/${name}` :
+      `https://github.com/vercel/pkg-fetch/releases/download/${tag}/${name}`;
 
   try {
     await downloadUrl(url, local);


### PR DESCRIPTION
All current packages are downloaded from the official github. However, in some network environments, it is not possible to effectively download the corresponding packages because of the inability to communicate with the public network.
Therefore, by adding the environment variable: `PKG_FETCH_MIRROR`, users can pre-sync packages from github to their own mirror environment, and then download them by configuring the environment variable:PKG_FETCH_MIRROR.