### PR TITLE
dockerfile.linux: use Node.js 16.x to avoid glibc issues

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -13,7 +13,7 @@ RUN yum install -y \
     make patch python2 \
     rh-python36-python
 
-RUN curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash -
+RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash -
 RUN yum install -y nodejs
 RUN npm install -g yarn
 


### PR DESCRIPTION
Related to #264 and fixes binary build failures that try to do `yum install nodejs @ 18.12.1` since the glibc requirements of _that_ nodejs package are >= 2.28, and it appears the nodejs we need in the environment of the Docker container is used for bootstrapping `pkg-fetch` to do the actual build

This should work as a workaround for now until a decision is made regarding whether to build on a newer runner for future node.js versions.