### PR TITLE
added withArmFpu to build node for a specific arm fpu

### DIFF
--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -14,6 +14,7 @@ async function main() {
     .option('node-range', { alias: 'n', default: 'latest', type: 'string' })
     .option('platform', { alias: 'p', default: hostPlatform, type: 'string' })
     .option('arch', { alias: 'a', default: hostArch, type: 'string' })
+    .option('with-arm-fpu', { default: "", type: 'string' })
     .option('test', { alias: 't', type: 'boolean' })
     .option('force-fetch', {
       alias: 'f',
@@ -37,6 +38,7 @@ async function main() {
     test,
     'force-fetch': forceFetch,
     'force-build': forceBuild,
+    'with-arm-fpu': withArmFpu,
     output,
   } = argv;
 
@@ -46,6 +48,7 @@ async function main() {
     arch,
     forceFetch,
     forceBuild,
+    withArmFpu,
     output,
   });
 

--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs';
 
-import { hostPlatform, hostArch } from './system';
+import { hostPlatform, hostArch, configureOptions } from './system';
 import { log } from './log';
 import { need } from './index';
 import { verify } from './verify';
@@ -15,6 +15,7 @@ async function main() {
     .option('platform', { alias: 'p', default: hostPlatform, type: 'string' })
     .option('arch', { alias: 'a', default: hostArch, type: 'string' })
     .option('with-arm-fpu', { default: "", type: 'string' })
+    .option('use-ninja', {default: false, type: 'boolean'})
     .option('test', { alias: 't', type: 'boolean' })
     .option('force-fetch', {
       alias: 'f',
@@ -38,9 +39,11 @@ async function main() {
     test,
     'force-fetch': forceFetch,
     'force-build': forceBuild,
-    'with-arm-fpu': withArmFpu,
     output,
   } = argv;
+
+  configureOptions.withArmFpu = argv['with-arm-fpu'];
+  configureOptions.useNinja = argv["use-ninja"];
 
   const local = await need({
     nodeRange,
@@ -48,7 +51,6 @@ async function main() {
     arch,
     forceFetch,
     forceBuild,
-    withArmFpu,
     output,
   });
 

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -227,6 +227,7 @@ async function compileOnUnix(
 
   if (cpu === 'arm' && withArmFpu) {
     args.push('--with-arm-fpu', withArmFpu);
+    args.push('--with-arm-float-abi', 'hard')
   }
 
   if (hostArch !== targetArch) {

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -237,6 +237,8 @@ async function compileOnUnix(
 
   args.push(...getConfigureArgs(getMajor(nodeVersion), targetPlatform));
 
+  log.info(`Running configure ${  args.join(" ")}`);
+
   // TODO same for windows?
   await spawn('/bin/sh', ['./configure', ...args], {
     cwd: nodePath,

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -230,6 +230,10 @@ async function compileOnUnix(
     args.push('--with-arm-float-abi', 'hard')
   }
 
+  if (fs.existsSync("/usr/bin/ninja")) {
+    args.push('--ninja')
+  }
+
   if (hostArch !== targetArch) {
     log.warn('Cross compiling!');
     log.warn('You are responsible for appropriate env like CC, CC_host, etc.');

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -207,7 +207,8 @@ const { MAKE_JOB_COUNT = os.cpus().length } = process.env;
 async function compileOnUnix(
   nodeVersion: string,
   targetArch: string,
-  targetPlatform: string
+  targetPlatform: string,
+  withArmFpu: string
 ) {
   const args = [];
   const cpu = {
@@ -222,6 +223,10 @@ async function compileOnUnix(
 
   if (cpu) {
     args.push('--dest-cpu', cpu);
+  }
+
+  if (cpu === 'arm' && withArmFpu) {
+    args.push('--with-arm-fpu', withArmFpu);
   }
 
   if (hostArch !== targetArch) {
@@ -272,7 +277,8 @@ async function compileOnUnix(
 async function compile(
   nodeVersion: string,
   targetArch: string,
-  targetPlatform: string
+  targetPlatform: string,
+  withArmFpu: string
 ) {
   log.info('Compiling Node.js from sources...');
   const win = hostPlatform === 'win';
@@ -281,14 +287,15 @@ async function compile(
     return compileOnWindows(nodeVersion, targetArch, targetPlatform);
   }
 
-  return compileOnUnix(nodeVersion, targetArch, targetPlatform);
+  return compileOnUnix(nodeVersion, targetArch, targetPlatform, withArmFpu);
 }
 
 export default async function build(
   nodeVersion: string,
   targetArch: string,
   targetPlatform: string,
-  local: string
+  local: string,
+  withArmFpu: string
 ) {
   await fs.remove(buildPath);
   await fs.mkdirp(nodePath);
@@ -298,7 +305,7 @@ export default async function build(
   await tarExtract(nodeVersion);
   await applyPatches(nodeVersion);
 
-  const output = await compile(nodeVersion, targetArch, targetPlatform);
+  const output = await compile(nodeVersion, targetArch, targetPlatform, withArmFpu);
   const outputHash = await hash(output);
 
   await fs.mkdirp(path.dirname(local));

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,11 +52,12 @@ interface NeedOptions {
   nodeRange: string;
   platform: string;
   arch: string;
+  withArmFpu: string;
 }
 
 export async function need(opts: NeedOptions) {
   // eslint-disable-line complexity
-  const { forceFetch, forceBuild, dryRun, output } = opts || {};
+  const { forceFetch, forceBuild, dryRun, output, withArmFpu } = opts || {};
   let { nodeRange, platform, arch } = opts || {};
 
   if (!nodeRange) throw wasReported('nodeRange not specified');
@@ -99,6 +100,7 @@ export async function need(opts: NeedOptions) {
     platform,
     version,
     output,
+    withArmFpu
   });
   const built = localPlace({
     from: 'built',
@@ -107,8 +109,9 @@ export async function need(opts: NeedOptions) {
     platform,
     version,
     output,
+    withArmFpu
   });
-  const remote = remotePlace({ arch, nodeVersion, platform, version });
+  const remote = remotePlace({ arch, nodeVersion, platform, version, withArmFpu });
 
   let fetchFailed;
 
@@ -180,7 +183,7 @@ export async function need(opts: NeedOptions) {
     return 'built';
   }
 
-  await build(nodeVersion, arch, platform, built);
+  await build(nodeVersion, arch, platform, built, withArmFpu);
   return built;
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,12 +52,11 @@ interface NeedOptions {
   nodeRange: string;
   platform: string;
   arch: string;
-  withArmFpu: string;
 }
 
 export async function need(opts: NeedOptions) {
   // eslint-disable-line complexity
-  const { forceFetch, forceBuild, dryRun, output, withArmFpu } = opts || {};
+  const { forceFetch, forceBuild, dryRun, output } = opts || {};
   let { nodeRange, platform, arch } = opts || {};
 
   if (!nodeRange) throw wasReported('nodeRange not specified');
@@ -99,8 +98,7 @@ export async function need(opts: NeedOptions) {
     nodeVersion,
     platform,
     version,
-    output,
-    withArmFpu
+    output
   });
   const built = localPlace({
     from: 'built',
@@ -108,10 +106,9 @@ export async function need(opts: NeedOptions) {
     nodeVersion,
     platform,
     version,
-    output,
-    withArmFpu
+    output
   });
-  const remote = remotePlace({ arch, nodeVersion, platform, version, withArmFpu });
+  const remote = remotePlace({ arch, nodeVersion, platform, version });
 
   let fetchFailed;
 
@@ -183,7 +180,7 @@ export async function need(opts: NeedOptions) {
     return 'built';
   }
 
-  await build(nodeVersion, arch, platform, built, withArmFpu);
+  await build(nodeVersion, arch, platform, built);
   return built;
 }
 

--- a/lib/places.ts
+++ b/lib/places.ts
@@ -20,6 +20,7 @@ interface PlaceOptions {
   nodeVersion: string;
   platform: string;
   arch: string;
+  withArmFpu: string;
 }
 
 interface LocalPlaceOptions extends PlaceOptions {
@@ -34,6 +35,7 @@ export function localPlace({
   nodeVersion,
   platform,
   arch,
+                             withArmFpu
 }: LocalPlaceOptions) {
   let binDir: string;
 
@@ -47,7 +49,7 @@ export function localPlace({
 
   return path.resolve(
     binDir,
-    `${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}`
+    withArmFpu?`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}-${withArmFpu}`:`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}`
   );
 }
 
@@ -61,9 +63,10 @@ export function remotePlace({
   nodeVersion,
   platform,
   arch,
+                              withArmFpu
 }: PlaceOptions): Remote {
   return {
     tag: tagFromVersion(version),
-    name: `node-${nodeVersion}-${platform}-${arch}`,
+    name: withArmFpu?`node-${nodeVersion}-${platform}-${arch}-${withArmFpu}`:`node-${nodeVersion}-${platform}-${arch}`,
   };
 }

--- a/lib/places.ts
+++ b/lib/places.ts
@@ -1,6 +1,7 @@
 import { major, minor } from 'semver';
 import os from 'os';
 import path from 'path';
+import {configureOptions} from "./system";
 
 const { PKG_CACHE_PATH } = process.env;
 const IGNORE_TAG = Boolean(process.env.PKG_IGNORE_TAG);
@@ -20,7 +21,6 @@ interface PlaceOptions {
   nodeVersion: string;
   platform: string;
   arch: string;
-  withArmFpu: string;
 }
 
 interface LocalPlaceOptions extends PlaceOptions {
@@ -34,8 +34,7 @@ export function localPlace({
   version,
   nodeVersion,
   platform,
-  arch,
-                             withArmFpu
+  arch
 }: LocalPlaceOptions) {
   let binDir: string;
 
@@ -49,7 +48,7 @@ export function localPlace({
 
   return path.resolve(
     binDir,
-    withArmFpu?`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}-${withArmFpu}`:`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}`
+    configureOptions.withArmFpu?`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}-${configureOptions.withArmFpu}`:`${output ? 'node' : from}-${nodeVersion}-${platform}-${arch}`
   );
 }
 
@@ -62,11 +61,10 @@ export function remotePlace({
   version,
   nodeVersion,
   platform,
-  arch,
-                              withArmFpu
+  arch
 }: PlaceOptions): Remote {
   return {
     tag: tagFromVersion(version),
-    name: withArmFpu?`node-${nodeVersion}-${platform}-${arch}-${withArmFpu}`:`node-${nodeVersion}-${platform}-${arch}`,
+    name: configureOptions.withArmFpu?`node-${nodeVersion}-${platform}-${arch}-${configureOptions.withArmFpu}`:`node-${nodeVersion}-${platform}-${arch}`,
   };
 }

--- a/lib/system.ts
+++ b/lib/system.ts
@@ -106,3 +106,10 @@ export const knownPlatforms = getKnownPlatforms();
 export const hostArch = getHostArch();
 export const targetArchs = getTargetArchs();
 export const knownArchs = getKnownArchs();
+
+interface ConfigureOptions {
+  withArmFpu: string;
+  useNinja: boolean;
+}
+
+export const configureOptions: ConfigureOptions = {withArmFpu: "", useNinja: false};


### PR DESCRIPTION
Hello there! 
The FPU instruction implementation on ARM cpu can vary and even being partial. (https://embeddedartistry.com/blog/2017/10/11/demystifying-arm-floating-point-compiler-options/)
For this reason our device using a SAMA5D3 cpu is not able to run node binaries compiled with the default configure options. (https://github.com/nodejs/node/issues/28906)
So I added the ability to specify the arm fpu variant on the pkg-fetch command line.

In the process I also added the option to use ninja to speed up the build time. But honestly I never been able to build successfully node with ninja :D

Thank you
Andrea
 
